### PR TITLE
Force the Apple Video/Audio Toolbox in GStreamer transforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
   CPATH: /usr/local/include
   LIBRARY_PATH: /usr/local/lib
   CFLAGS: -O3 -Wno-deprecated-declarations -Wno-incompatible-pointer-types
-  CROSSCFLAGS: -O3
+  CROSSCFLAGS: -O3 -Wno-int-conversion -Wno-incompatible-pointer-types
   LDFLAGS: -Wl,-ld_classic -Wl,-headerpad_max_install_names -Wl,-rpath,@loader_path/../../ -Wl,-rpath,/usr/local/lib
   MACOSX_DEPLOYMENT_TARGET: 10.14
   WINE_CONFIGURE: $GITHUB_WORKSPACE/configure


### PR DESCRIPTION
I noticed some situations in which GStreamer fails to initialize when launching Steam because it can't find a way to decode H.264 byte-stream video via Quartz or MF (not sure). I'm don't know why Steam needs to decode H.264 at launch (maybe to probe Windows features?) In any case, this patch fixes the issue and should make H.264 and AAC decoding more robust.

Whisky Wine doesn't bundle `libgstlibav.dylib`, which links to FFmpeg and is what is typically used to actually decode AV streams with GStreamer. As a result, `wg_transform_create` with these kinds of streams always fails. Whisky Wine does bundle `libgstapplemedia.dylib`, which includes integrations with Apple Video Toolbox and Audio Toolbox. The Video Toolbox (`vtdec` or `vtdec_hw` in GStreamer) expects a packetized H.264 stream, i.e. `stream-format = avc` and not `byte-stream`; likewise, the Audio Toolbox expects a pre-framed input stream. We can use `h264parse` and `aacparse` for these, and this patch essentially forces that pre-parsing to happen.

This doesn't seem to always be the codepath for general video decoding; Wine seems to use GStreamer's autoplug for that in some situations via `wg_parser.c`. I'm not actually sure what situations would trigger this patch specifically, but given that this causes GStreamer transform initializations to actually work; it might help.

*Note: this change is ported from [this patch for CX24](https://github.com/101arrowz/cxbuilder/blob/master/patches/apple-gstreamer.patch); it was only tested on CX24, not Whisky Wine*