### PR TITLE
Proton & CW HACK 23072 Simulate Write Copy

### DIFF
--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -2465,6 +2465,20 @@ static void dlopen_32on64_opengl32(void)
 }
 #endif
 
+BOOL simulate_writecopy;
+
+static void hacks_init(void)
+{
+    const char *env_str;
+
+    env_str = getenv("WINE_SIMULATE_WRITECOPY");
+    if (env_str) simulate_writecopy = atoi(env_str);
+    else simulate_writecopy = main_argc > 1 && (
+        strstr(main_argv[1], "UplayWebCore.exe")
+        || strstr(main_argv[1], "Battle.net.exe") /* CW HACK 23072 */
+    );
+}
+
 /***********************************************************************
  *           start_main_thread
  */
@@ -2479,6 +2493,7 @@ static void start_main_thread(void)
     signal_init_thread( teb );
     dbg_init();
     startup_info_size = server_init_process();
+    hacks_init();
     msync_init();
     esync_init();
     virtual_map_user_shared_data();

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -163,6 +163,7 @@ extern USHORT ds32_sel DECLSPEC_HIDDEN;
 extern USHORT cs64_sel DECLSPEC_HIDDEN;
 #endif
 
+extern BOOL simulate_writecopy;
 
 extern void init_environment( int argc, char *argv[], char *envp[] ) DECLSPEC_HIDDEN;
 extern void init_startup_info(void) DECLSPEC_HIDDEN;

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -120,6 +120,7 @@ struct file_view
 #define VPROT_GUARD      0x10
 #define VPROT_COMMITTED  0x20
 #define VPROT_WRITEWATCH 0x40
+#define VPROT_COPIED     0x80
 /* per-mapping protection flags */
 #define VPROT_SYSTEM     0x0200  /* system view (underlying mmap not under our control) */
 

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -4145,23 +4145,6 @@ NTSTATUS WINAPI NtProtectVirtualMemory( HANDLE process, PVOID *addr_ptr, SIZE_T 
                 vprot |= VPROT_COPIED;
                 old = get_win32_prot( vprot, view->protect );
             }
-            else if (status == STATUS_SUCCESS && (view->protect & SEC_IMAGE) &&
-                     base == (void*)NtCurrentTeb()->Peb->ImageBaseAddress)
-            {
-                /* GTA5 HACK: Mark first page as copied. */
-                const WCHAR gta5W[] = { 'g','t','a','5','.','e','x','e',0 };
-                WCHAR *name, *p;
-
-                name = NtCurrentTeb()->Peb->ProcessParameters->ImagePathName.Buffer;
-                p = wcsrchr(name, '\\');
-                p = p ? p+1 : name;
-
-                if(!wcsicmp(p, gta5W))
-                {
-                    FIXME("HACK: changing GTA5.exe vprot\n");
-                    set_page_vprot_bits(base, page_size, VPROT_COPIED, 0);
-                }
-            }
         }
         else status = STATUS_NOT_COMMITTED;
     }


### PR DESCRIPTION
Adds fixes for Battle.Net with Proton's `WINE_SIMULATE_WRITECOPY` that patches `NtProtectedVirtualMemory`'s behaviour.

`hacks_init` provided from CX 23.7.1's patchset.